### PR TITLE
Patched QuantumMoon.OnDisable bug

### DIFF
--- a/VanillaFix/QuantumMoonFix.cs
+++ b/VanillaFix/QuantumMoonFix.cs
@@ -1,0 +1,21 @@
+using HarmonyLib;
+using OWML.Utils;
+using UnityEngine;
+
+namespace VanillaFix;
+
+[HarmonyPatch(typeof(QuantumMoon))]
+public static class QuantumMoonFix
+{
+	[HarmonyPrefix]
+	[HarmonyPatch(nameof(QuantumMoon.OnDisable))]
+	public static void OnDisablePatch(QuantumMoon __instance)
+	{
+		//Original OnDisable:		this._outerCloudTransform.gameObject.SetActive(false);
+		//Problem: this does not check if _outerCloudTransform is null before trying to disable its gameObject
+		//Solution: if _outerCloudTransform is null, create a new dummy GameObject to sate OnDisable's appetite
+		Transform outerCloudTransform = __instance.GetValue<Transform>("_outerCloudTransform");
+		if (outerCloudTransform == null)
+			__instance.SetValue("_outerCloudTransform", new GameObject().transform);
+	}
+}

--- a/VanillaFix/QuantumMoonFix.cs
+++ b/VanillaFix/QuantumMoonFix.cs
@@ -16,6 +16,31 @@ public static class QuantumMoonFix
 		//Solution: if _outerCloudTransform is null, create a new dummy GameObject to sate OnDisable's appetite
 		Transform outerCloudTransform = __instance.GetValue<Transform>("_outerCloudTransform");
 		if (outerCloudTransform == null)
-			__instance.SetValue("_outerCloudTransform", new GameObject().transform);
+		{
+			GameObject fodderGameObject = new GameObject();
+			fodderGameObject.AddComponent<SelfDestructor>();
+			__instance.SetValue("_outerCloudTransform", fodderGameObject.transform);
+		}
+	}
+}
+
+/// <summary>
+/// Destroys the gameObject it's attached to after a few seconds or on disable
+/// </summary>
+public class SelfDestructor : MonoBehaviour
+{
+	private float timer = 0f;
+	public float destructionTime = 3f;
+
+	private void Update()
+	{
+		timer += Time.deltaTime;
+		if (timer > destructionTime)
+			this.gameObject.SetActive(false);
+	}
+
+	private void OnDisable()
+	{
+		Destroy(this.gameObject);
 	}
 }

--- a/VanillaFix/VanillaFix.csproj
+++ b/VanillaFix/VanillaFix.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <LangVersion>default</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Copyright>Copyright © 2020</Copyright>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
Original OnDisable:
```
private void OnDisable()
{
    this._outerCloudTransform.gameObject.SetActive(false);
}
```
Problem: this does not check if _outerCloudTransform is null before trying to disable its gameObject

Solution: if _outerCloudTransform is null, create a new self-destructing GameObject to sate OnDisable's appetite