### PR TITLE
Fixed fog lingering when teleporting out of Bramble

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Fixes some vanilla bugs in Outer Wilds
 - Fixes a softlock with ship logs and mods with custom facts (like The Outsider).
 - Fixes a hard-to-find visual bug with projection pools.
 - [Fixes an issue where probe would sometimes stretch when anchored to an object](https://github.com/JohnCorby/ow-vanilla-fix/issues/7). This isn't a perfect solution, but it is not possible to do it better in unity.
+- Fixes an issue where fog shaders are not updated when the `PlayerFogWarpDetector` is disabled (resulted in permanent fog on screen if you leave Bramble too quickly, ie, by teleporting)

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Fixes some vanilla bugs in Outer Wilds
 - Fixes a softlock with ship logs and mods with custom facts (like The Outsider).
 - Fixes a hard-to-find visual bug with projection pools.
 - [Fixes an issue where probe would sometimes stretch when anchored to an object](https://github.com/JohnCorby/ow-vanilla-fix/issues/7). This isn't a perfect solution, but it is not possible to do it better in unity.
-- Fixes an issue where fog shaders are not updated when the `PlayerFogWarpDetector` is disabled (resulted in permanent fog on screen if you leave Bramble too quickly, ie, by teleporting)
+- Fixes an issue where fog shaders are not updated when the `PlayerFogWarpDetector` is disabled (resulted in permanent fog on screen if you leave Bramble too quickly, ie, by teleporting) (credit to xen)

--- a/VanillaFix/PersistentFogFix.cs
+++ b/VanillaFix/PersistentFogFix.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+
+namespace VanillaFix;
+
+[HarmonyPatch]
+public static class PersistentFogFix
+{
+    [HarmonyPostfix, HarmonyPatch(typeof(PlayerFogWarpDetector), nameof(PlayerFogWarpDetector.OnDisable))]
+    public static void PlayerFogWarpDetector_OnDisable(PlayerFogWarpDetector __instance)
+    {
+        // In the base game method, Mobius only sets _fogFraction to 0; they forget to actually pass that value to the shaders
+        // Since it's been disabled, this code never ends up running since its in LateUpdate
+
+        if (__instance._playerEffectBubbleController != null)
+        {
+            __instance._playerEffectBubbleController.SetFogFade(__instance._fogFraction, __instance._fogColor);
+        }
+        if (__instance._shipLandingCamEffectBubbleController != null)
+        {
+            __instance._shipLandingCamEffectBubbleController.SetFogFade(__instance._fogFraction, __instance._fogColor);
+        }
+    }
+}

--- a/VanillaFix/manifest.json
+++ b/VanillaFix/manifest.json
@@ -3,6 +3,6 @@
   "author": "JohnCorby",
   "name": "Vanilla Fix",
   "uniqueName": "JohnCorby.VanillaFix",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "owmlVersion": "2.9.5"
 }


### PR DESCRIPTION
In the base game PlayerFogWarpDetector.OnDisable method, Mobius only sets _fogFraction to 0; they forget to actually pass that value to the shaders so it lingers on screen until you re-enter a fog warp volume (the code that normally updates the shaders is in LateUpdate which doesn't run since the component is disabled).