### PR TITLE
Fix #26 by setting dialogue option's texts as wrap

### DIFF
--- a/VanillaFix/DialogueOptionOverflowInCJKFix.cs
+++ b/VanillaFix/DialogueOptionOverflowInCJKFix.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+
+namespace VanillaFix;
+
+/// <summary>
+/// UiSizeSetterDialogueOption changes the dialogue option's text's horizontalOverflow as Overflow when the language is CJK (Chinese, Japanese, or Koreans).
+/// This causes an overflow problem when the dialogue option's text is so long.
+/// See https://github.com/JohnCorby/ow-vanilla-fix/issues/26
+/// </summary>
+[HarmonyPatch]
+public class DialogueOptionOverflowInCJKFix
+{
+    [HarmonyPostfix, HarmonyPatch(typeof(UiSizeSetterDialogueOption), nameof(UiSizeSetterDialogueOption.DoResizeAction))]
+    public static void UiSizeSetterDialogueOption_DoResizeAction(UiSizeSetterDialogueOption __instance, UITextSize textSizeSetting)
+    {
+        if(TextTranslation.Get().IsLanguageCJK())
+        {
+            __instance._textField.horizontalOverflow = UnityEngine.HorizontalWrapMode.Wrap;
+        }
+    }
+}


### PR DESCRIPTION
This pull request resolves #26.
![スクリーンショット (6754)](https://github.com/user-attachments/assets/9d9bd4a3-bb97-4434-b325-1ecb1e04eb8c)
![スクリーンショット (6755)](https://github.com/user-attachments/assets/2f53c001-7e80-4c01-8452-0b7905489a57)
![スクリーンショット (6757)](https://github.com/user-attachments/assets/7cda45dd-e275-4f1a-bd32-6e2546b12ea7)
