### PR TITLE
Signalscope Waveform UI Fix

### DIFF
--- a/VanillaFix/SignalscopeUIFix.cs
+++ b/VanillaFix/SignalscopeUIFix.cs
@@ -14,5 +14,5 @@ public static class SignalscopeUIFix
 {
 	[HarmonyPostfix]
 	[HarmonyPatch(nameof(SignalscopeUI.Start))]
-	private static void Start(SignalscopeUI __instance) => __instance.SetWaveformUIActive(false);
+	private static void Start(SignalscopeUI __instance) => __instance._waveformRenderer.enabled = false;
 }

--- a/VanillaFix/SignalscopeUIFix.cs
+++ b/VanillaFix/SignalscopeUIFix.cs
@@ -1,0 +1,18 @@
+﻿using HarmonyLib;
+using UnityEngine;
+
+namespace VanillaFix;
+
+/// <summary>
+/// CREDIT TO SPACEMIKE FOR THIS FIX
+///
+/// Part of the waveform UI for the signalscope is active at the start of the scene before the
+/// signalscope is pulled out and ends up just floating in space before you equip the signalscope.
+/// </summary>
+[HarmonyPatch(typeof(SignalscopeUI))]
+public static class SignalscopeUIFix
+{
+	[HarmonyPostfix]
+	[HarmonyPatch(nameof(SignalscopeUI.Start))]
+	private static void Start(SignalscopeUI __instance) => __instance.SetWaveformUIActive(false);
+}


### PR DESCRIPTION
Added new fix to disable part of the Signalscope Waveform UI at the start of the scene to prevent it from floating in space and being visible before the Signalscope is pulled out.

This UI element will usually be spotted as a small rectangle floating in space before the signalscope is pulled out, and can break part of the immersion, especially since it is drawn on top of everything and thus can be seen through walls. You can see an example of this random UI element below:
![SignalscopeUI](https://github.com/user-attachments/assets/ce839eb4-7d5a-45e7-8eb6-ebb67e4321ec)
